### PR TITLE
Add stop:docker script

### DIFF
--- a/alchemy-starter/README.md
+++ b/alchemy-starter/README.md
@@ -22,6 +22,10 @@ Use this template if you want to develop on Alchemy Interface while also editing
 
         npm run launch:docker
 
+- Stop Alchemy-server and Graph-node
+
+        npm run stop:docker
+
 ## (Optional) Deploy DAO
     
 - Edit `data/testDaoSpec.json` with specifications for your DAO

--- a/alchemy-starter/package.json
+++ b/alchemy-starter/package.json
@@ -10,6 +10,7 @@
     "build:client": "cd client && npm i && npm run build && npm link",
     "deploy:graph": "bash ops/deploy-graph.sh",
     "launch:docker": "cd alchemy && docker-compose up -d graph-node alchemy-server",
+    "stop:docker": "cd alchemy && docker-compose stop",
     "link:client": "cd alchemy && npm link @daostack/client",
     "migrate": "node ops/deployDao.js",
     "start:alchemy": "cd alchemy && npm run start",


### PR DESCRIPTION
Add `stop:docker` script to alchemy-starter.
It stops docker containers started by `launch:docker`.